### PR TITLE
Python Database Migrator Some Times Cannot Connect to Postgres Database on Startup #18

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -53,7 +53,7 @@ services:
     container_name: python-db-migrator
     depends_on:
       - postgres-db
-    restart: no
+    restart: on-failure
     build:
       context: ./db
     networks:


### PR DESCRIPTION
- This kind of hides the issue, but it only happens the first time when the container is created, it doesn't happen with each subsequent update, but on the other hand restart on failure is probably also a good thing for the migrator